### PR TITLE
Create code-of-conduct.md

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,53 @@
+# Adoption of document for the OpenData Community
+This a draft until voted on and adopted by the ODC Jedi
+
+# DRAFT Contributor Code of Conduct
+
+As contributors and maintainers in the OpenData Community (ODC), and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute
+through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in the ODC community a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+
+## Scope 
+
+This Code of Conduct applies within all project spaces, and it also applies when an individual is representing the project or its community in public spaces. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## ODC Events
+
+ODC events, or events run by ODC sponsor or partner staff, are governed by the same ODC code of conduct. 
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Focusing on what is best not just for us as individuals, but for the overall community
+* Showing empathy towards other community members
+* Do not misrepresent your identity in a deceptive or harmful way. This includes creating fake profiles and attempts to impersonate an individual, group, or organization
+* Do not engage in activities that could damage or compromise the security of an account, network, or system
+* Do not use or attempt to use ODC to promote, coordinate, or execute financial scams
+* Do not engage in activities that fraudulently generate a profit at the expense of others
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+* Sending unsolicited bulk messages (or spam) to others
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. 
+
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+## Enforcement 
+
+Instances of abusive, harassing, fraudulent, or otherwise unacceptable behavior may be reported by contacting the project team at code@opendatacommunity.org. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+## Acknowledgements
+This Code of Conduct is adapted from the CNCF Community Code of Conduct version 1.2 available at
+https://github.com/cncf/foundation/ and Gitcoin Code of Conduct version 2022 available at https://support.gitcoin.co/gitcoin-knowledge-base/gitcoin-policy/code-of-conduct, and Discord Community Guidelines 27 March 2023 available at https://discord.com/guidelines.


### PR DESCRIPTION
This was using a sample of well known organizations that we will likely interact with. It appears many are using similar language, which is not surprising. Following my own experience and the advice of Metagov, this and other governance documents will attempt to define the least amount of rules and process until necessary to do so.

# Researched OSS communities codes of conduct
- CNCF: Good start on how to set broad rules to allow teams to self organize
- Gitcoin: very similar to CNCF with some good changes
- ENS: similar language to others. A bit too much detail that makes it harder to follow.
- Discord: a few service abuse references that were included
- Openstack (OpenInfra): very focused on conflicts of interest. We do not have enough commercial contribution to be worried about this yet.
- Giveth: very similar to the text already used